### PR TITLE
remove oblosete info

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Programming languages differ on multiple dimensions, such as [paradigm](https://
 * [Rholang](https://rholang.rchain.coop/) - a reflective higher-order process calculus language (RChain)
 * [Obsidian](https://mcoblenz.github.io/Obsidian/) - a state-oriented language with linear types
 * [DAML](http://hub.digitalasset.com/blog/introducing-the-digital-asset-modeling-language-a-powerful-alternative-to-smart-contracts-for-financial-institutions)
-* [Qtum smart contract language (QSCL)](https://qtum.org/uploads/files/a2772efe4dc8ed1100319c6480195fb1.pdf) - no details, also mentioned in an [article](https://bitcoinmagazine.com/articles/qtum-forges-ahead-development-its-x86-virtual-machine-and-expanded-network/)
 * [Simvolio](https://apla.io/)
 * [Marlowe](https://twitter.com/IOHK_Charles/status/963837766957137921) (Cardano)
 * [Waves contract language](https://github.com/wavesplatform/Waves/wiki/Waves-Contracts-Language-Description) (Waves)


### PR DESCRIPTION
Looks like there is no QSLC language:
* old [link](https://qtum.org/uploads/files/a2772efe4dc8ed1100319c6480195fb1.pdf) is dead
* they [use Solidity](https://docs.qtum.site/en/QRC20-Token-Introduce.html) for smart contracts?