### PR TITLE
add CashScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Programming languages differ on multiple dimensions, such as [paradigm](https://
 * [Sapio](https://www.coindesk.com/this-new-coding-language-could-help-unlock-bitcoins-smart-contract-potential)
 * [Minsc](https://min.sc/) - a high-level scripting language for expressing Bitcoin Script spending conditions based on Miniscript Policy
 * [Bithoven](https://github.com/ChrisCho-H/bithoven) -  A High-Level, Imperative Language for Bitcoin Smart Contracts, featuring an LR(1) parser with static analysis for compile-time safety.
+* [CashScript](https://github.com/CashScript/cashscript) - a high-level language for smart contracts on Bitcoin Cash with covenant functionality. [Docs](https://cashscript.org/)
 
 
 # Ethereum


### PR DESCRIPTION
PR to add CashScript to this repo of smart contract languages

some background info:

CashScript was created in 2019 as a master thesis project and has had continued development ever since.
CashScript website: https://cashscript.org/

The master thesis compares other existing high-level Bitcoin smart contract languages at the time like Ivy and Spedn: 
https://kalis.me/uploads/msc-thesis.pdf

CashScript added abstractions for covenant functionality in Dec of 2019.
CashScript was incubated by bitcoindotcom by is now a stand-alone open source project.
https://github.com/CashScript

CashScript has been forked multiple times for other chains (for the Nexa blockchain, for the Elements blockchain, and most recently for Arkade script)